### PR TITLE
Do not allocate Intl and Temporal objects from the finalized GC kind

### DIFF
--- a/src/intl/IntlCollator.cpp
+++ b/src/intl/IntlCollator.cpp
@@ -145,14 +145,6 @@ IntlCollator::CollatorResolvedOptions IntlCollator::resolvedOptions(ExecutionSta
     return opt;
 }
 
-static void intlCollatorClear(void* obj, void* cd)
-{
-    Object* self = reinterpret_cast<Object*>(obj);
-    if (self->extraData()) {
-        ucol_close((UCollator*)self->extraData());
-    }
-}
-
 void IntlCollator::initialize(ExecutionState& state, Object* collator, Context* realm, Value locales, Value options)
 {
     // http://www.ecma-international.org/ecma-402/1.0/index.html#sec-10.1.1.1
@@ -165,8 +157,18 @@ void IntlCollator::initialize(ExecutionState& state, Object* collator, Context* 
     }
 
     // Set the [[initializedIntlObject]] internal property of collator to true.
-    constexpr static GC_finalizer_closure data = { intlCollatorClear, nullptr };
-    collator->setInternalSlot(new (GC_finalized_malloc(sizeof(Object), &data)) Object(state, Object::PrototypeIsNull));
+    // The internal slot object must not come from the finalized kind: that kind
+    // is marked unconditionally, so the slot - and with it the Intl object's
+    // whole Context - would stay reachable forever. Release the ICU handle
+    // from a regular finalizer instead.
+    collator->setInternalSlot(new Object(state, Object::PrototypeIsNull));
+    collator->internalSlot()->addFinalizer([](PointerValue* self, void* data) {
+        Object* slot = self->asObject();
+        if (slot->extraData()) {
+            ucol_close((UCollator*)slot->extraData());
+        }
+    },
+                                           nullptr);
     collator->internalSlot()->defineOwnProperty(state, ObjectPropertyName(initializedIntlObject), ObjectPropertyDescriptor(Value(true)));
 
     // Let requestedLocales be the result of calling the

--- a/src/intl/IntlDateTimeFormat.cpp
+++ b/src/intl/IntlDateTimeFormat.cpp
@@ -507,16 +507,14 @@ static String* icuFieldTypeToPartName(ExecutionState& state, int32_t fieldName)
     }
 }
 
-void intlDateTimeFormatClear(void* obj, void* cd)
-{
-    IntlDateTimeFormatObject* self = reinterpret_cast<IntlDateTimeFormatObject*>(obj);
-    self->clearNativeResources();
-}
-
 void* IntlDateTimeFormatObject::operator new(size_t size)
 {
-    constexpr static GC_finalizer_closure data = { intlDateTimeFormatClear, nullptr };
-    return GC_finalized_malloc(size, &data);
+    // Allocating from the finalized kind would turn every instance into a GC
+    // root - that kind is marked unconditionally - which keeps the object's
+    // prototype chain, and through it the whole Context, reachable long after
+    // the page that created it is gone. A regular finalizer releases the
+    // native resources without pinning anything.
+    return GC_MALLOC(size);
 }
 
 void IntlDateTimeFormatObject::clearNativeResources()
@@ -545,6 +543,10 @@ IntlDateTimeFormatObject::IntlDateTimeFormatObject(ExecutionState& state, Object
     , m_timeZoneICU(String::emptyString())
     , m_icuDateFormat(nullptr)
 {
+    addFinalizer([](PointerValue* self, void* data) {
+        static_cast<IntlDateTimeFormatObject*>(self->asObject())->clearNativeResources();
+    },
+                 nullptr);
     // Let requestedLocales be ? CanonicalizeLocaleList(locales).
     ValueVector requestedLocales = Intl::canonicalizeLocaleList(state, locales);
     auto toDateTimeOptionsResult = toDateTimeOptions(state, options, state.context()->staticStrings().lazyAny().string(), state.context()->staticStrings().lazyDate().string());

--- a/src/intl/IntlDateTimeFormat.h
+++ b/src/intl/IntlDateTimeFormat.h
@@ -34,9 +34,8 @@ public:
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;
     void clearNativeResources();
-    // Objects allocated via GC_finalized_malloc must not be freed with GC_FREE or delete.
-    // Calling delete would invoke GC_FREE internally, which crashes because the memory
-    // was not allocated by GC_malloc. The no-op operator delete below prevents this.
+    // Instances are GC allocated and their native resources are released by a
+    // finalizer, so deletion is left to the collector: operator delete is a no-op.
     void operator delete(void*) {}
     void operator delete[](void*) = delete;
 

--- a/src/intl/IntlDisplayNames.cpp
+++ b/src/intl/IntlDisplayNames.cpp
@@ -30,16 +30,14 @@
 
 namespace Escargot {
 
-static void intlDisplayNamesClear(void* obj, void* cd)
-{
-    IntlDisplayNamesObject* self = reinterpret_cast<IntlDisplayNamesObject*>(obj);
-    self->clearNativeResources();
-}
-
 void* IntlDisplayNamesObject::operator new(size_t size)
 {
-    constexpr static GC_finalizer_closure data = { intlDisplayNamesClear, nullptr };
-    return GC_finalized_malloc(size, &data);
+    // Allocating from the finalized kind would turn every instance into a GC
+    // root - that kind is marked unconditionally - which keeps the object's
+    // prototype chain, and through it the whole Context, reachable long after
+    // the page that created it is gone. A regular finalizer releases the
+    // native resources without pinning anything.
+    return GC_MALLOC(size);
 }
 
 void IntlDisplayNamesObject::clearNativeResources()
@@ -58,6 +56,10 @@ IntlDisplayNamesObject::IntlDisplayNamesObject(ExecutionState& state, Object* pr
     , m_languageDisplay(nullptr)
     , m_icuLocaleDisplayNames(nullptr)
 {
+    addFinalizer([](PointerValue* self, void* data) {
+        static_cast<IntlDisplayNamesObject*>(self->asObject())->clearNativeResources();
+    },
+                 nullptr);
 #if defined(ENABLE_RUNTIME_ICU_BINDER)
     UVersionInfo versionArray;
     u_getVersion(versionArray);

--- a/src/intl/IntlDisplayNames.h
+++ b/src/intl/IntlDisplayNames.h
@@ -33,9 +33,8 @@ public:
     void* operator new(size_t size);
     void* operator new[](size_t size) = delete;
     void clearNativeResources();
-    // Objects allocated via GC_finalized_malloc must not be freed with GC_FREE or delete.
-    // Calling delete would invoke GC_FREE internally, which crashes because the memory
-    // was not allocated by GC_malloc. The no-op operator delete below prevents this.
+    // Instances are GC allocated and their native resources are released by a
+    // finalizer, so deletion is left to the collector: operator delete is a no-op.
     void operator delete(void*) {}
     void operator delete[](void*) = delete;
 

--- a/src/intl/IntlDurationFormat.cpp
+++ b/src/intl/IntlDurationFormat.cpp
@@ -63,16 +63,14 @@
 
 namespace Escargot {
 
-static void intlDurationFormatClear(void* obj, void* cd)
-{
-    IntlDurationFormatObject* self = reinterpret_cast<IntlDurationFormatObject*>(obj);
-    self->clearNativeResources();
-}
-
 void* IntlDurationFormatObject::operator new(size_t size)
 {
-    constexpr static GC_finalizer_closure data = { intlDurationFormatClear, nullptr };
-    return GC_finalized_malloc(size, &data);
+    // Allocating from the finalized kind would turn every instance into a GC
+    // root - that kind is marked unconditionally - which keeps the object's
+    // prototype chain, and through it the whole Context, reachable long after
+    // the page that created it is gone. A regular finalizer releases the
+    // native resources without pinning anything.
+    return GC_MALLOC(size);
 }
 
 void IntlDurationFormatObject::clearNativeResources()
@@ -179,6 +177,10 @@ static std::pair<String*, String*> getDurationUnitOptions(ExecutionState& state,
 IntlDurationFormatObject::IntlDurationFormatObject(ExecutionState& state, Object* proto, Value locales, Value optionsInput)
     : DerivedObject(state, proto)
 {
+    addFinalizer([](PointerValue* self, void* data) {
+        static_cast<IntlDurationFormatObject*>(self->asObject())->clearNativeResources();
+    },
+                 nullptr);
 #if defined(ENABLE_RUNTIME_ICU_BINDER)
     UVersionInfo versionArray;
     u_getVersion(versionArray);

--- a/src/intl/IntlDurationFormat.h
+++ b/src/intl/IntlDurationFormat.h
@@ -38,9 +38,8 @@ public:
 
     void* operator new(size_t size);
     void clearNativeResources();
-    // Objects allocated via GC_finalized_malloc must not be freed with GC_FREE or delete.
-    // Calling delete would invoke GC_FREE internally, which crashes because the memory
-    // was not allocated by GC_malloc. The no-op operator delete below prevents this.
+    // Instances are GC allocated and their native resources are released by a
+    // finalizer, so deletion is left to the collector: operator delete is a no-op.
     void operator delete(void*) {}
     void operator delete[](void*) = delete;
 

--- a/src/intl/IntlListFormat.cpp
+++ b/src/intl/IntlListFormat.cpp
@@ -33,16 +33,14 @@
 
 namespace Escargot {
 
-static void intlListFormatClear(void* obj, void* cd)
-{
-    IntlListFormatObject* self = reinterpret_cast<IntlListFormatObject*>(obj);
-    self->clearNativeResources();
-}
-
 void* IntlListFormatObject::operator new(size_t size)
 {
-    constexpr static GC_finalizer_closure data = { intlListFormatClear, nullptr };
-    return GC_finalized_malloc(size, &data);
+    // Allocating from the finalized kind would turn every instance into a GC
+    // root - that kind is marked unconditionally - which keeps the object's
+    // prototype chain, and through it the whole Context, reachable long after
+    // the page that created it is gone. A regular finalizer releases the
+    // native resources without pinning anything.
+    return GC_MALLOC(size);
 }
 
 void IntlListFormatObject::clearNativeResources()
@@ -59,6 +57,10 @@ IntlListFormatObject::IntlListFormatObject(ExecutionState& state, Object* proto,
     , m_style(nullptr)
     , m_icuListFormatter(nullptr)
 {
+    addFinalizer([](PointerValue* self, void* data) {
+        static_cast<IntlListFormatObject*>(self->asObject())->clearNativeResources();
+    },
+                 nullptr);
     // https://tc39.es/ecma402/#sec-Intl.ListFormat
 #if defined(ENABLE_RUNTIME_ICU_BINDER)
     UVersionInfo versionArray;

--- a/src/intl/IntlListFormat.h
+++ b/src/intl/IntlListFormat.h
@@ -32,9 +32,8 @@ public:
 
     void* operator new(size_t size);
     void clearNativeResources();
-    // Objects allocated via GC_finalized_malloc must not be freed with GC_FREE or delete.
-    // Calling delete would invoke GC_FREE internally, which crashes because the memory
-    // was not allocated by GC_malloc. The no-op operator delete below prevents this.
+    // Instances are GC allocated and their native resources are released by a
+    // finalizer, so deletion is left to the collector: operator delete is a no-op.
     void operator delete(void*) {}
     void operator delete[](void*) = delete;
 

--- a/src/intl/IntlNumberFormat.cpp
+++ b/src/intl/IntlNumberFormat.cpp
@@ -310,19 +310,6 @@ struct IntlNumberFormatData {
     Optional<UNumberRangeFormatter*> numberRangeFormatter;
 };
 
-static void intlNumberFormatClear(void* obj, void* cd)
-{
-    Object* self = reinterpret_cast<Object*>(obj);
-    if (self->extraData()) {
-        auto ud = reinterpret_cast<IntlNumberFormatData*>(self->extraData());
-        unumf_close(ud->numberFormatter);
-        if (ud->numberRangeFormatter) {
-            unumrf_close(ud->numberRangeFormatter.value());
-        }
-        delete ud;
-    }
-}
-
 void IntlNumberFormat::initialize(ExecutionState& state, Object* numberFormat, Value locales, Value options)
 {
 #if defined(ENABLE_RUNTIME_ICU_BINDER)
@@ -340,8 +327,23 @@ void IntlNumberFormat::initialize(ExecutionState& state, Object* numberFormat, V
     }
 
     // Set the [[initializedIntlObject]] internal property of dateTimeFormat to true.
-    constexpr static GC_finalizer_closure fData = { intlNumberFormatClear, nullptr };
-    numberFormat->setInternalSlot(new (GC_finalized_malloc(sizeof(Object), &fData)) Object(state, Object::PrototypeIsNull));
+    // The internal slot object must not come from the finalized kind: that kind
+    // is marked unconditionally, so the slot - and with it the Intl object's
+    // whole Context - would stay reachable forever. Release the ICU handles
+    // from a regular finalizer instead.
+    numberFormat->setInternalSlot(new Object(state, Object::PrototypeIsNull));
+    numberFormat->internalSlot()->addFinalizer([](PointerValue* self, void* data) {
+        Object* slot = self->asObject();
+        if (slot->extraData()) {
+            auto ud = reinterpret_cast<IntlNumberFormatData*>(slot->extraData());
+            unumf_close(ud->numberFormatter);
+            if (ud->numberRangeFormatter) {
+                unumrf_close(ud->numberRangeFormatter.value());
+            }
+            delete ud;
+        }
+    },
+                                               nullptr);
     numberFormat->internalSlot()->defineOwnProperty(state, ObjectPropertyName(state, initializedIntlObject), ObjectPropertyDescriptor(Value(true)));
 
     // Let requestedLocales be the result of calling the

--- a/src/intl/IntlRelativeTimeFormat.cpp
+++ b/src/intl/IntlRelativeTimeFormat.cpp
@@ -32,16 +32,14 @@
 
 namespace Escargot {
 
-static void intlRelativeTimeFormatClear(void* obj, void* cd)
-{
-    IntlRelativeTimeFormatObject* self = reinterpret_cast<IntlRelativeTimeFormatObject*>(obj);
-    self->clearNativeResources();
-}
-
 void* IntlRelativeTimeFormatObject::operator new(size_t size)
 {
-    constexpr static GC_finalizer_closure data = { intlRelativeTimeFormatClear, nullptr };
-    return GC_finalized_malloc(size, &data);
+    // Allocating from the finalized kind would turn every instance into a GC
+    // root - that kind is marked unconditionally - which keeps the object's
+    // prototype chain, and through it the whole Context, reachable long after
+    // the page that created it is gone. A regular finalizer releases the
+    // native resources without pinning anything.
+    return GC_MALLOC(size);
 }
 
 void IntlRelativeTimeFormatObject::clearNativeResources()
@@ -85,6 +83,10 @@ IntlRelativeTimeFormatObject::IntlRelativeTimeFormatObject(ExecutionState& state
     , m_numeric(nullptr)
     , m_icuRelativeDateTimeFormatter(nullptr)
 {
+    addFinalizer([](PointerValue* self, void* data) {
+        static_cast<IntlRelativeTimeFormatObject*>(self->asObject())->clearNativeResources();
+    },
+                 nullptr);
 #if defined(ENABLE_RUNTIME_ICU_BINDER)
     UVersionInfo versionArray;
     u_getVersion(versionArray);

--- a/src/intl/IntlRelativeTimeFormat.h
+++ b/src/intl/IntlRelativeTimeFormat.h
@@ -33,9 +33,8 @@ public:
 
     void* operator new(size_t size);
     void clearNativeResources();
-    // Objects allocated via GC_finalized_malloc must not be freed with GC_FREE or delete.
-    // Calling delete would invoke GC_FREE internally, which crashes because the memory
-    // was not allocated by GC_malloc. The no-op operator delete below prevents this.
+    // Instances are GC allocated and their native resources are released by a
+    // finalizer, so deletion is left to the collector: operator delete is a no-op.
     void operator delete(void*) {}
     void operator delete[](void*) = delete;
 

--- a/src/intl/IntlSegmenter.cpp
+++ b/src/intl/IntlSegmenter.cpp
@@ -29,16 +29,14 @@
 
 namespace Escargot {
 
-static void intlSegmenterClear(void* obj, void* cd)
-{
-    IntlSegmenterObject* self = reinterpret_cast<IntlSegmenterObject*>(obj);
-    self->clearNativeResources();
-}
-
 void* IntlSegmenterObject::operator new(size_t size)
 {
-    constexpr static GC_finalizer_closure data = { intlSegmenterClear, nullptr };
-    return GC_finalized_malloc(size, &data);
+    // Allocating from the finalized kind would turn every instance into a GC
+    // root - that kind is marked unconditionally - which keeps the object's
+    // prototype chain, and through it the whole Context, reachable long after
+    // the page that created it is gone. A regular finalizer releases the
+    // native resources without pinning anything.
+    return GC_MALLOC(size);
 }
 
 void IntlSegmenterObject::clearNativeResources()
@@ -56,6 +54,10 @@ IntlSegmenterObject::IntlSegmenterObject(ExecutionState& state, Value locales, V
 IntlSegmenterObject::IntlSegmenterObject(ExecutionState& state, Object* proto, Value locales, Value optionsInput)
     : DerivedObject(state, proto)
 {
+    addFinalizer([](PointerValue* self, void* data) {
+        static_cast<IntlSegmenterObject*>(self->asObject())->clearNativeResources();
+    },
+                 nullptr);
 #if defined(ENABLE_RUNTIME_ICU_BINDER)
     UVersionInfo versionArray;
     u_getVersion(versionArray);

--- a/src/intl/IntlSegmenter.h
+++ b/src/intl/IntlSegmenter.h
@@ -36,9 +36,8 @@ public:
 
     void* operator new(size_t size);
     void clearNativeResources();
-    // Objects allocated via GC_finalized_malloc must not be freed with GC_FREE or delete.
-    // Calling delete would invoke GC_FREE internally, which crashes because the memory
-    // was not allocated by GC_malloc. The no-op operator delete below prevents this.
+    // Instances are GC allocated and their native resources are released by a
+    // finalizer, so deletion is left to the collector: operator delete is a no-op.
     void operator delete(void*) {}
     void operator delete[](void*) = delete;
 

--- a/src/runtime/TemporalPlainDateObject.cpp
+++ b/src/runtime/TemporalPlainDateObject.cpp
@@ -33,16 +33,14 @@
 
 namespace Escargot {
 
-static void temporalPlainDateClear(void* obj, void* cd)
-{
-    TemporalPlainDateObject* self = reinterpret_cast<TemporalPlainDateObject*>(obj);
-    self->clearNativeResources();
-}
-
 void* TemporalPlainDateObject::operator new(size_t size)
 {
-    constexpr static GC_finalizer_closure data = { temporalPlainDateClear, nullptr };
-    return GC_finalized_malloc(size, &data);
+    // Allocating from the finalized kind would turn every instance into a GC
+    // root - that kind is marked unconditionally - which keeps the object's
+    // prototype chain, and through it the whole Context, reachable long after
+    // the page that created it is gone. A regular finalizer releases the
+    // native resources without pinning anything.
+    return GC_MALLOC(size);
 }
 
 void TemporalPlainDateObject::clearNativeResources()
@@ -62,6 +60,10 @@ TemporalPlainDateObject::TemporalPlainDateObject(ExecutionState& state, Object* 
     , m_plainDate(new(PointerFreeGC) ISO8601::PlainDate(isoDate))
     , m_calendarID(calendar)
 {
+    addFinalizer([](PointerValue* self, void* data) {
+        static_cast<TemporalPlainDateObject*>(self->asObject())->clearNativeResources();
+    },
+                 nullptr);
     if (checkBoundery && !ISO8601::isoDateTimeWithinLimits(isoDate.year(), isoDate.month(), isoDate.day())) {
         ErrorObject::throwBuiltinError(state, ErrorCode::RangeError, "Out of range date");
     }
@@ -89,6 +91,10 @@ TemporalPlainDateObject::TemporalPlainDateObject(ExecutionState& state, Object* 
     , m_calendarID(calendar)
     , m_icuCalendar(fieldResolveResult.first)
 {
+    addFinalizer([](PointerValue* self, void* data) {
+        static_cast<TemporalPlainDateObject*>(self->asObject())->clearNativeResources();
+    },
+                 nullptr);
     if (fieldResolveResult.second) {
         *m_plainDate = fieldResolveResult.second.value();
     } else {
@@ -117,6 +123,10 @@ TemporalPlainDateObject::TemporalPlainDateObject(ExecutionState& state, Object* 
     , m_calendarID(calendar)
     , m_icuCalendar(icuCalendar)
 {
+    addFinalizer([](PointerValue* self, void* data) {
+        static_cast<TemporalPlainDateObject*>(self->asObject())->clearNativeResources();
+    },
+                 nullptr);
     UErrorCode status = U_ZERO_ERROR;
 
     auto y = calendar.year(state, m_icuCalendar);

--- a/src/runtime/TemporalPlainDateObject.h
+++ b/src/runtime/TemporalPlainDateObject.h
@@ -48,9 +48,8 @@ public:
 
     void* operator new(size_t size);
     void clearNativeResources();
-    // Objects allocated via GC_finalized_malloc must not be freed with GC_FREE or delete.
-    // Calling delete would invoke GC_FREE internally, which crashes because the memory
-    // was not allocated by GC_malloc. The no-op operator delete below prevents this.
+    // Instances are GC allocated and their native resources are released by a
+    // finalizer, so deletion is left to the collector: operator delete is a no-op.
     void operator delete(void*) {}
     void operator delete[](void*) = delete;
 

--- a/src/runtime/TemporalPlainDateTimeObject.cpp
+++ b/src/runtime/TemporalPlainDateTimeObject.cpp
@@ -53,16 +53,14 @@
 
 namespace Escargot {
 
-static void temporalPlainDateTimeClear(void* obj, void* cd)
-{
-    TemporalPlainDateTimeObject* self = reinterpret_cast<TemporalPlainDateTimeObject*>(obj);
-    self->clearNativeResources();
-}
-
 void* TemporalPlainDateTimeObject::operator new(size_t size)
 {
-    constexpr static GC_finalizer_closure data = { temporalPlainDateTimeClear, nullptr };
-    return GC_finalized_malloc(size, &data);
+    // Allocating from the finalized kind would turn every instance into a GC
+    // root - that kind is marked unconditionally - which keeps the object's
+    // prototype chain, and through it the whole Context, reachable long after
+    // the page that created it is gone. A regular finalizer releases the
+    // native resources without pinning anything.
+    return GC_MALLOC(size);
 }
 
 void TemporalPlainDateTimeObject::clearNativeResources()
@@ -82,6 +80,10 @@ TemporalPlainDateTimeObject::TemporalPlainDateTimeObject(ExecutionState& state, 
     , m_plainDateTime(new(PointerFreeGC) ISO8601::PlainDateTime(isoDate, plainTime))
     , m_calendarID(calendar)
 {
+    addFinalizer([](PointerValue* self, void* data) {
+        static_cast<TemporalPlainDateTimeObject*>(self->asObject())->clearNativeResources();
+    },
+                 nullptr);
     if (!ISO8601::isDateTimeWithinLimits(isoDate.year(), isoDate.month(), isoDate.day(),
                                          plainTime.hour(), plainTime.minute(), plainTime.second(), plainTime.microsecond(), plainTime.microsecond(), plainTime.nanosecond())) {
         ErrorObject::throwBuiltinError(state, ErrorCode::RangeError, "Invalid date-time");
@@ -119,6 +121,10 @@ TemporalPlainDateTimeObject::TemporalPlainDateTimeObject(ExecutionState& state, 
     , m_calendarID(calendar)
     , m_icuCalendar(icuCalendar)
 {
+    addFinalizer([](PointerValue* self, void* data) {
+        static_cast<TemporalPlainDateTimeObject*>(self->asObject())->clearNativeResources();
+    },
+                 nullptr);
     ASSERT(underMicrosecondValue < 1000 * 1000);
     UErrorCode status = U_ZERO_ERROR;
 

--- a/src/runtime/TemporalPlainDateTimeObject.h
+++ b/src/runtime/TemporalPlainDateTimeObject.h
@@ -33,9 +33,8 @@ public:
 
     void* operator new(size_t size);
     void clearNativeResources();
-    // Objects allocated via GC_finalized_malloc must not be freed with GC_FREE or delete.
-    // Calling delete would invoke GC_FREE internally, which crashes because the memory
-    // was not allocated by GC_malloc. The no-op operator delete below prevents this.
+    // Instances are GC allocated and their native resources are released by a
+    // finalizer, so deletion is left to the collector: operator delete is a no-op.
     void operator delete(void*) {}
     void operator delete[](void*) = delete;
 

--- a/src/runtime/TemporalZonedDateTimeObject.cpp
+++ b/src/runtime/TemporalZonedDateTimeObject.cpp
@@ -30,16 +30,14 @@
 
 namespace Escargot {
 
-static void temporalZonedDateTimeClear(void* obj, void* cd)
-{
-    TemporalZonedDateTimeObject* self = reinterpret_cast<TemporalZonedDateTimeObject*>(obj);
-    self->clearNativeResources();
-}
-
 void* TemporalZonedDateTimeObject::operator new(size_t size)
 {
-    constexpr static GC_finalizer_closure data = { temporalZonedDateTimeClear, nullptr };
-    return GC_finalized_malloc(size, &data);
+    // Allocating from the finalized kind would turn every instance into a GC
+    // root - that kind is marked unconditionally - which keeps the object's
+    // prototype chain, and through it the whole Context, reachable long after
+    // the page that created it is gone. A regular finalizer releases the
+    // native resources without pinning anything.
+    return GC_MALLOC(size);
 }
 
 void TemporalZonedDateTimeObject::clearNativeResources()
@@ -135,6 +133,10 @@ TemporalZonedDateTimeObject::TemporalZonedDateTimeObject(ExecutionState& state, 
     , m_calendarID(calendar)
     , m_icuCalendar(nullptr)
 {
+    addFinalizer([](PointerValue* self, void* data) {
+        static_cast<TemporalZonedDateTimeObject*>(self->asObject())->clearNativeResources();
+    },
+                 nullptr);
     ComputedTimeZone computedTimeZone;
     if (timeZone.hasTimeZoneName()) {
         Int128 timezoneAppliedEpoch = Temporal::getEpochNanosecondsFor(state, timeZone, epochNanoseconds, TemporalDisambiguationOption::Compatible);
@@ -156,6 +158,10 @@ TemporalZonedDateTimeObject::TemporalZonedDateTimeObject(ExecutionState& state, 
     , m_calendarID(calendar)
     , m_icuCalendar(nullptr)
 {
+    addFinalizer([](PointerValue* self, void* data) {
+        static_cast<TemporalZonedDateTimeObject*>(self->asObject())->clearNativeResources();
+    },
+                 nullptr);
     init(state, timeZone);
 }
 

--- a/src/runtime/TemporalZonedDateTimeObject.h
+++ b/src/runtime/TemporalZonedDateTimeObject.h
@@ -76,9 +76,8 @@ public:
 
     void* operator new(size_t size);
     void clearNativeResources();
-    // Objects allocated via GC_finalized_malloc must not be freed with GC_FREE or delete.
-    // Calling delete would invoke GC_FREE internally, which crashes because the memory
-    // was not allocated by GC_malloc. The no-op operator delete below prevents this.
+    // Instances are GC allocated and their native resources are released by a
+    // finalizer, so deletion is left to the collector: operator delete is a no-op.
     void operator delete(void*) {}
     void operator delete[](void*) = delete;
 

--- a/src/runtime/VMInstance.h
+++ b/src/runtime/VMInstance.h
@@ -134,9 +134,10 @@ public:
     void enterIdleMode();
     // Drops every compiled ByteCodeBlock, including the ones of top level code
     // blocks that enterIdleMode() leaves to the Script class. Only safe when
-    // this VM is about to be discarded: a ByteCodeBlock is allocated through
-    // GC_finalized_malloc, and that kind is marked unconditionally, so each
-    // one keeps its Context (and everything the Context reaches) alive.
+    // this VM is about to be discarded: ByteCodeBlockKind is registered with
+    // GC_register_disclaim_proc(..., mark_from_all = 1), so every block is
+    // marked whether or not anything references it and keeps its Context (and
+    // everything the Context reaches) alive.
     void releaseAllByteCodeBlocks();
     void clearCachesRelatedWithContext();
 


### PR DESCRIPTION
`GC_finalized_malloc` allocates from a kind that `GC_init_finalized_malloc` registers with `ok_mark_unconditionally = TRUE` (`fnlz_mlc.c:100-110`). Objects of such a kind are marked whether or not anything references them, and marking traces their fields — for a JS object that means its prototype chain, hence the global object and the whole `Context`. A collection cycle strips only one level off that chain, so a realistic object graph survives many cycles.

Eleven allocation sites had this property, all of them JS objects holding GC pointers: `IntlCollator`, `IntlDateTimeFormat`, `IntlDisplayNames`, `IntlDurationFormat`, `IntlListFormat`, `IntlNumberFormat`, `IntlRelativeTimeFormat`, `IntlSegmenter`, `TemporalPlainDate`, `TemporalPlainDateTime`, `TemporalZonedDateTime`.

## Measurements

An embedder loads a page, reloads it five times, then collects without scanning thread stacks and counts every live object:

| page | live objects | live documents |
|---|---|---|
| one `Intl.DateTimeFormat` | 52,990 | 6 (current + five dead) |
| same page, no `Intl` call | 8,666 | 1 |
| one `Intl.DateTimeFormat`, with this change | 10,221 | 1 |

With ten reloads the same page went from 4 live documents to 1.

## Change

The objects are allocated from the normal kind and release their native resources from a regular finalizer registered through `addFinalizer()`, which also composes with the finalizers `WeakRef` and `FinalizationRegistry` install on the same object (a raw `GC_REGISTER_FINALIZER_NO_ORDER` would be overwritten by those paths).

`Intl.Collator` and `Intl.NumberFormat` keep their ICU handle on an internal slot object, so that object is what moves to the normal kind.

`BigInt` keeps `GC_finalized_atomic_malloc`: its payload holds no GC pointers, so it pins nothing.

## Verification

- `Intl.DateTimeFormat`, `Intl.NumberFormat` (currency), `Intl.Collator` and `Intl.RelativeTimeFormat` all still produce correct output.
- 20,000 short lived `Intl.DateTimeFormat` objects leave RSS flat (177–180 MB), so the ICU handles are still released.
- No exceptions, assertions or crashes across the reload runs above.

Based on `feature/release-all-bytecode-blocks`; the second commit only corrects a comment introduced there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJ9c4JQsaJLq2eTfKDxFFZ